### PR TITLE
feat: declarative pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 def runIntegrationTests() {
     withDockerContainer(image: 'circleci/node:dubnium-stretch', args: '-u root --network aerogear') {
-        sh "JUNIT_REPORT_PATH=report-${env.MOBILE_PLATFORM}.xml npm start -- --reporter mocha-jenkins-reporter test/auth/*.js || true"
+        sh "JUNIT_REPORT_PATH=report-${env.MOBILE_PLATFORM}.xml npm start -- --reporter mocha-jenkins-reporter test/**/*.js || true"
         archiveArtifacts "report-${env.MOBILE_PLATFORM}.xml"
         junit allowEmptyResults: true, testResults: "report-${env.MOBILE_PLATFORM}.xml"
     }
@@ -45,7 +45,7 @@ pipeline {
           }
         }
 
-        stage('Build iOS') {
+        stage('iOS') {
           agent { 
             label 'osx5x'
           }
@@ -66,7 +66,7 @@ pipeline {
 
     stage('Testing') {
       stages {
-        stage('start services') {
+        stage('Start services') {
           steps {
               sh """
               docker network create aerogear || true
@@ -86,7 +86,7 @@ pipeline {
                 }
             }
         }
-        stage('test android') {
+        stage('Test android') {
           environment { 
             MOBILE_PLATFORM = 'android'
           }
@@ -95,7 +95,7 @@ pipeline {
             runIntegrationTests()
           }
         }
-        stage('test ios') {
+        stage('Test ios') {
           environment { 
             MOBILE_PLATFORM = 'ios'
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
             GOOGLE_SERVICES = credentials('google-services')
           }
           steps {
-            git branch: 'master', url: 'https://github.com/aerogear/aerogear-integration-tests.git'
+            checkout scm
             withDockerContainer(image: 'circleci/android:api-28-node', args: '-u root') {
               sh """
               apt update
@@ -53,7 +53,7 @@ pipeline {
             MOBILE_PLATFORM = 'ios'
           }
           steps {
-            git branch: 'master', url: 'https://github.com/aerogear/aerogear-integration-tests.git'
+            checkout scm
             sh """#!/usr/bin/env bash -l
             npm -g install cordova
             security unlock-keychain -p $KEYCHAIN_PASS && ./scripts/build-testing-app.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,165 +1,120 @@
-def releaseJS() {
-  sh 'npm set registry http://verdaccio:4873/'
-  sh 'npx npm-cli-login -u test -p test -e test@example.com -r http://verdaccio:4873'
-  sh 'git config --global user.email "test@example.com"'
-  sh 'git config --global user.name "test"'
-  sh 'npx lerna version patch --no-push --yes'
-  sh 'CI=true npm run release:prep'
-  sh 'TAG=\$(node -e "console.log(require(\'./lerna.json\').version);") npm run release:validate'
-  sh 'TAG=\$(node -e "console.log(require(\'./lerna.json\').version);") CI=true npm run publish'
+def runIntegrationTests() {
+    withDockerContainer(image: 'circleci/node:dubnium-stretch', args: '-u root --network aerogear') {
+        sh "JUNIT_REPORT_PATH=report-${env.MOBILE_PLATFORM}.xml npm start -- --reporter mocha-jenkins-reporter test/auth/*.js || true"
+        archiveArtifacts "report-${env.MOBILE_PLATFORM}.xml"
+        junit allowEmptyResults: true, testResults: "report-${env.MOBILE_PLATFORM}.xml"
+    }
 }
 
-def runTests() {
-  sh 'CI=true JUNIT_REPORT_PATH=report-$MOBILE_PLATFORM.xml JUNIT_REPORT_STACK=1 npm start -- --reporter mocha-jenkins-reporter test/**/*.js || true'
-  archiveArtifacts "report-${env.MOBILE_PLATFORM}.xml"
-  junit allowEmptyResults: true, testResults: "report-${env.MOBILE_PLATFORM}.xml"
-}
+pipeline {
+  agent {
+    label 'psi_rhel8'
+  }
+  environment {
+    BROWSERSTACK_USER = credentials('browserstack-user')
+    BROWSERSTACK_KEY = credentials('browserstack-key')
+    FIREBASE_SERVER_KEY = credentials('firebase-server-key')
+    FIREBASE_SENDER_ID = credentials('firebase-sender-id')
+    FASTLANE_USER = credentials('fastlane-user')
+    FASTLANE_PASSWORD = credentials('fastlane-password')
+    MATCH_PASSWORD = credentials('match-password')
+    KEYCHAIN_PASS = credentials('mac2-password')
+    CI = "true"
+    JUNIT_REPORT_STACK="1"
+  }
+  stages {
+    stage('Build Testing App') {
+      parallel {
 
-node('psi_rhel8') {
-  cleanWs()
-  linuxNodeIP = sh(returnStdout: true, script: 'echo $OPENSTACK_PUBLIC_IP').trim()
-  buildAerogear = buildAerogear.toString() == 'true'
+        stage('Android') {
+          environment {
+            GOOGLE_SERVICES = credentials('google-services')
+          }
+          steps {
+            git branch: 'master', url: 'https://github.com/aerogear/aerogear-integration-tests.git'
+            withDockerContainer(image: 'circleci/android:api-28-node', args: '-u root') {
+              sh """
+              apt update
+              apt install gradle
+              npm -g install cordova
+              cp ${GOOGLE_SERVICES} ./fixtures/google-services.json
+              ./scripts/build-testing-app.sh
+              """
+              stash includes: 'testing-app/bs-app-url.txt', name: 'android-testing-app'
+            }
+          }
+        }
 
-  try {
-    sh 'docker network create aerogear'
-
-    // npm proxy registry - used for js publishing testing
-    docker.image('verdaccio/verdaccio').withRun('--network aerogear --name verdaccio -p 4873:4873') {
-      withCredentials([
-        usernamePassword(
-          credentialsId: 'browserstack',
-          usernameVariable: 'BROWSERSTACK_USER',
-          passwordVariable: 'BROWSERSTACK_KEY'
-        ),
-        string(credentialsId: 'firebase-server-key', variable: 'FIREBASE_SERVER_KEY'),
-        string(credentialsId: 'firebase-sender-id', variable: 'FIREBASE_SENDER_ID'),
-        string(credentialsId: 'fastlane-user', variable: 'FASTLANE_USER'),
-        string(credentialsId: 'fastlane-password', variable: 'FASTLANE_PASSWORD'),
-        string(credentialsId: 'match-password', variable: 'MATCH_PASSWORD'),
-        string(credentialsId: 'mac2-password', variable: 'KEYCHAIN_PASS')
-      ]) {
-        stage('Build js-sdk') {
-          if (buildAerogear) {
-            docker.image('circleci/node:dubnium-stretch').inside('-u root:root --network aerogear') {
-              dir('aerogear-js-sdk') {
-                git branch: 'master', url: 'https://github.com/aerogear/aerogear-js-sdk.git'
-                releaseJS()
-              }
-            }
-          } else {
-            echo 'Skipping the build'
+        stage('Build iOS') {
+          agent { 
+            label 'osx5x'
           }
-        }
-        stage('Build app-metrics') {
-          if (buildAerogear) {
-            dir('aerogear-app-metrics') {
-              docker.image('circleci/golang:stretch').inside('-u root:root') {
-                git branch: 'master', url: 'https://github.com/aerogear/aerogear-app-metrics.git'
-                sh 'mkdir -p /go/src/github.com/aerogear'
-                sh 'ln -s \$(pwd) /go/src/github.com/aerogear'
-                sh 'cd /go/src/github.com/aerogear/aerogear-app-metrics && make build_linux'
-              }
-              sh 'docker build -t aerogear/aerogear-app-metrics:latest --build-arg BINARY=./dist/linux_amd64/aerogear-app-metrics .'
-            }
-          } else {
-            echo 'Skipping the build'
+          environment { 
+            MOBILE_PLATFORM = 'ios'
           }
-        }
-        stage('Build voyager-server') {
-          if (buildAerogear.toString() == 'true') {
-            docker.image('circleci/node:dubnium-stretch').inside('-u root:root --network aerogear') {
-              dir('voyager-server') {
-                git branch: 'master', url: 'https://github.com/aerogear/voyager-server.git'
-                releaseJS()
-              }
-            }
-          } else {
-              echo 'Skipping the build'
-          }
-        }
-        stage('Build testing app') {
-          parallel Android: {
-            docker.image('circleci/android:api-28-node').inside('-u root:root --network aerogear') {
-              dir('aerogear-integration-tests') {
-                sh 'npm set registry http://verdaccio:4873/'
-                sh 'apt update'
-                sh 'apt install gradle'
-                sh 'npm -g install cordova'
-                checkout scm
-                withCredentials([file(credentialsId: 'google-services', variable: 'GOOGLE_SERVICES')]) {
-                  sh 'cp ${GOOGLE_SERVICES} ./fixtures/google-services.json'
-                  sh './scripts/build-testing-app.sh'
-                }
-                androidAppUrl = sh(returnStdout: true, script: 'cat "./testing-app/bs-app-url.txt" | cut -d \'"\' -f 4').trim()
-              }
-            }
-          },
-          iOS: {
-            node('osx5x') {
-              cleanWs()
-              withEnv(['MOBILE_PLATFORM=ios']) {
-                dir('aerogear-integration-tests-osx') {
-                  originalRegistry = sh(script: 'npm get registry', returnStdout: true).trim()
-                  try {
-                    sh "npm set registry http://${linuxNodeIP}:4873/"
-                    sh 'npm -g install cordova'
-                    checkout scm
-                    sh '''#!/usr/bin/env bash -l
-                      security unlock-keychain -p $KEYCHAIN_PASS && ./scripts/build-testing-app.sh
-                    '''
-                    iosAppUrl = sh(returnStdout: true, script: 'cat "./testing-app/bs-app-url.txt" | cut -d \'"\' -f 4').trim()
-                  } catch (e) {
-                    throw e
-                  } finally {
-                    sh "npm set registry ${originalRegistry}"
-                  }
-                }
-              }
-            }
-          }
-        }
-        dir('aerogear-integration-tests') {
-          try {
-            stage('Start services') {
-              sh 'sudo curl -L "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-\$(uname -s)-\$(uname -m)" -o /usr/local/bin/docker-compose'
-              sh 'sudo chmod +x /usr/local/bin/docker-compose'
-              sh 'docker-compose up -d'
-            }
-            docker.image('circleci/node:dubnium-stretch').inside('-u root:root --network aerogear') {
-              stage('Test Android') {
-                sh 'npm set registry http://verdaccio:4873/'
-                sh 'npm install'
-                sh 'npm install mocha-jenkins-reporter'
-                withEnv([
-                  'MOBILE_PLATFORM=android',
-                  'BROWSERSTACK_APP=' + androidAppUrl
-                ]) {
-                  runTests()
-                }
-              }
-              stage('Test iOS') {
-                withEnv([
-                  'MOBILE_PLATFORM=ios',
-                  'BROWSERSTACK_APP=' + iosAppUrl
-                ]) {    
-                  runTests()
-                }
-              }
-            }
-          } catch (e) {
-            throw e
-          } finally {
-            sh 'docker-compose logs --no-color > docker-compose.log'
-            sh 'docker-compose down'
-            archiveArtifacts "docker-compose.log"
+          steps {
+            git branch: 'master', url: 'https://github.com/aerogear/aerogear-integration-tests.git'
+            sh """#!/usr/bin/env bash -l
+            npm -g install cordova
+            security unlock-keychain -p $KEYCHAIN_PASS && ./scripts/build-testing-app.sh
+            """
+            stash includes: 'testing-app/bs-app-url.txt', name: 'ios-testing-app'        
           }
         }
       }
     }
-  } catch (e) {
-    throw e
-  } finally {
-    sh 'docker rmi aerogear/aerogear-app-metrics:latest || true'
-    sh 'docker network rm aerogear || true'
+
+    stage('Testing') {
+      stages {
+        stage('start services') {
+          steps {
+              sh """
+              docker network create aerogear || true
+              docker-compose up -d
+              # To remove ownership of root user from testing-app folder
+              sudo chown -R jenkins:jenkins .
+              """
+          }
+        }
+        stage('Install dependencies for tests') {
+            steps {
+                withDockerContainer(image: 'circleci/node:dubnium-stretch', args: '-u root') {
+                  sh """
+                  npm install
+                  npm install mocha-jenkins-reporter
+                  """
+                }
+            }
+        }
+        stage('test android') {
+          environment { 
+            MOBILE_PLATFORM = 'android'
+          }
+          steps {
+            unstash 'android-testing-app'
+            runIntegrationTests()
+          }
+        }
+        stage('test ios') {
+          environment { 
+            MOBILE_PLATFORM = 'ios'
+          }
+          steps {
+            unstash 'ios-testing-app'
+            runIntegrationTests()
+          }
+        }
+      }
+      post { 
+        always {
+          sh """
+          docker-compose logs --no-color > docker-compose.log
+          docker-compose down
+          docker network rm aerogear || true
+          """
+          archiveArtifacts 'docker-compose.log'
+        }
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": ". ./scripts/setup-env-vars.sh && mocha --file util/init.js"
   },
   "dependencies": {
-    "@aerogear/voyager-server": "latest",
+    "@aerogear/voyager-server": "dev",
     "axios": "^0.19.0",
     "chai": "^4.2.0",
     "express": "latest",

--- a/scripts/build-testing-app.sh
+++ b/scripts/build-testing-app.sh
@@ -27,7 +27,8 @@ npm install --save \
   webpack \
   webpack-cli \
   graphql \
-  graphql-tag
+  graphql-tag \
+  offix-cache
 
 cordova plugin add @aerogear/cordova-plugin-aerogear-metrics
 cordova plugin add @aerogear/cordova-plugin-aerogear-security

--- a/scripts/build-testing-app.sh
+++ b/scripts/build-testing-app.sh
@@ -19,20 +19,19 @@ fi
 cd testing-app
 
 npm install --save \
-  @aerogear/security \
-  @aerogear/app \
-  @aerogear/auth \
-  @aerogear/voyager-client \
-  @aerogear/push \
+  @aerogear/security@dev \
+  @aerogear/app@dev \
+  @aerogear/auth@dev \
+  @aerogear/voyager-client@dev \
+  @aerogear/push@dev \
   webpack \
   webpack-cli \
   graphql \
-  graphql-tag \
-  offix-cache
+  graphql-tag
 
-cordova plugin add @aerogear/cordova-plugin-aerogear-metrics
-cordova plugin add @aerogear/cordova-plugin-aerogear-security
-cordova plugin add @aerogear/cordova-plugin-aerogear-sync
+cordova plugin add @aerogear/cordova-plugin-aerogear-metrics@dev
+cordova plugin add @aerogear/cordova-plugin-aerogear-security@dev
+cordova plugin add @aerogear/cordova-plugin-aerogear-sync@dev
 cordova plugin add cordova-plugin-inappbrowser
 
 npx webpack
@@ -48,7 +47,7 @@ if [ "$MOBILE_PLATFORM" = "ios" ]; then
 else
 
   # push tests works only in android
-  cordova plugin add @aerogear/cordova-plugin-aerogear-push
+  cordova plugin add @aerogear/cordova-plugin-aerogear-push@dev
 
   cordova platform add android || true
   cordova build android


### PR DESCRIPTION
This PR removes `build` steps of components from previous version of the pipeline, because we won't need to build them once we are able to test `master` tag of components.

Successful build: https://mobile-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/%20Playground/job/integration-tests-pg/78/