### PR TITLE
Added missing dependency

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,7 @@ node('psi_rhel8') {
         string(credentialsId: 'fastlane-user', variable: 'FASTLANE_USER'),
         string(credentialsId: 'fastlane-password', variable: 'FASTLANE_PASSWORD'),
         string(credentialsId: 'match-password', variable: 'MATCH_PASSWORD'),
+        string(credentialsId: 'mac2-password', variable: 'KEYCHAIN_PASS')
       ]) {
         stage('Build js-sdk') {
           if (buildAerogear) {
@@ -104,7 +105,7 @@ node('psi_rhel8') {
                     sh 'npm -g install cordova'
                     checkout scm
                     sh '''#!/usr/bin/env bash -l
-                      ./scripts/build-testing-app.sh
+                      security unlock-keychain -p $KEYCHAIN_PASS && ./scripts/build-testing-app.sh
                     '''
                     iosAppUrl = sh(returnStdout: true, script: 'cat "./testing-app/bs-app-url.txt" | cut -d \'"\' -f 4').trim()
                   } catch (e) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,7 @@ node('psi_rhel8') {
                 sh 'npm set registry http://verdaccio:4873/'
                 sh 'apt update'
                 sh 'apt install gradle'
-                sh 'npm -g install cordova@8'
+                sh 'npm -g install cordova'
                 checkout scm
                 withCredentials([file(credentialsId: 'google-services', variable: 'GOOGLE_SERVICES')]) {
                   sh 'cp ${GOOGLE_SERVICES} ./fixtures/google-services.json'
@@ -101,7 +101,7 @@ node('psi_rhel8') {
                   originalRegistry = sh(script: 'npm get registry', returnStdout: true).trim()
                   try {
                     sh "npm set registry http://${linuxNodeIP}:4873/"
-                    sh 'npm -g install cordova@8'
+                    sh 'npm -g install cordova'
                     checkout scm
                     sh '''#!/usr/bin/env bash -l
                       ./scripts/build-testing-app.sh

--- a/fixtures/fastlane/fastlane/Fastfile
+++ b/fixtures/fastlane/fastlane/Fastfile
@@ -8,8 +8,7 @@ platform :ios do
       release: false,
       device: true,
       type: "development",
-      team_id: "GHPBX39444",
-      build_flag: ["-UseModernBuildSystem=0"]
+      team_id: "GHPBX39444"
     )
   end
 end

--- a/scripts/build-testing-app.sh
+++ b/scripts/build-testing-app.sh
@@ -26,7 +26,8 @@ npm install --save \
   @aerogear/push \
   webpack \
   webpack-cli \
-  graphql
+  graphql \
+  graphql-tag
 
 cordova plugin add @aerogear/cordova-plugin-aerogear-metrics
 cordova plugin add @aerogear/cordova-plugin-aerogear-security


### PR DESCRIPTION
## Motivation

With recent changes in aerogear-js-sdk, graphql-tag package was moved to devDependencies, so it's no longer included in voyager-client.

Also tests should use latest cordova.

Plus fix for iOS build.

https://mobile-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/%20Playground/job/integ-tests-verification/14/