### PR TITLE
Fixed sync test - breaking changes in voyager-client/offix

### DIFF
--- a/test/sync/index.js
+++ b/test/sync/index.js
@@ -97,7 +97,12 @@ describe('Data Sync', function() {
         window.aerogear.itemsQuery = itemsQuery;
 
         const cacheUpdates = {
-          create: getUpdateFunction('create', 'id', CacheOperation.ADD, itemsQuery)
+          create: getUpdateFunction({
+            mutationName: 'create',
+            idField: 'id',
+            operationType: CacheOperation.ADD,
+            updateQuery: itemsQuery
+          })
         };
       
         const options = {
@@ -155,7 +160,7 @@ describe('Data Sync', function() {
       try {
         const { apolloClient, gql, itemsQuery } = window.aerogear;
 
-        await apolloClient.offlineMutation({
+        await apolloClient.offlineMutate({
           mutation: gql`
             mutation create($title: String!) {
               create(title: $title) {


### PR DESCRIPTION
## Motivation

Currently sync tests fail [1] because of breaking changes in js-sdk, e.g. [2].

[1] https://mobile-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/integration-tests/257/
[2] https://github.com/aerogear/aerogear-js-sdk/blob/master/RELEASE_NOTES.md#cache-helper-interface