### PR TITLE
Improve declerative pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,15 +1,11 @@
 def runIntegrationTests() {
-    withDockerContainer(image: 'circleci/node:dubnium-stretch', args: '-u root --network aerogear') {
-        sh "JUNIT_REPORT_PATH=report-${env.MOBILE_PLATFORM}.xml npm start -- --reporter mocha-jenkins-reporter test/**/*.js || true"
-        archiveArtifacts "report-${env.MOBILE_PLATFORM}.xml"
-        junit allowEmptyResults: true, testResults: "report-${env.MOBILE_PLATFORM}.xml"
-    }
+  sh "JUNIT_REPORT_PATH=report-${env.MOBILE_PLATFORM}.xml npm start -- --reporter mocha-jenkins-reporter test/**/*.js || true"
+  archiveArtifacts "report-${env.MOBILE_PLATFORM}.xml"
+  junit allowEmptyResults: true, testResults: "report-${env.MOBILE_PLATFORM}.xml"
 }
 
 pipeline {
-  agent {
-    label 'psi_rhel8'
-  }
+  agent none
   environment {
     BROWSERSTACK_USER = credentials('browserstack-user')
     BROWSERSTACK_KEY = credentials('browserstack-key')
@@ -19,7 +15,6 @@ pipeline {
     FASTLANE_PASSWORD = credentials('fastlane-password')
     MATCH_PASSWORD = credentials('match-password')
     KEYCHAIN_PASS = credentials('mac2-password')
-    CI = "true"
     JUNIT_REPORT_STACK="1"
   }
   stages {
@@ -27,21 +22,23 @@ pipeline {
       parallel {
 
         stage('Android') {
+          agent {
+            dockerfile {
+              dir 'containers/android/'
+              filename 'Dockerfile'
+              label 'psi_rhel8'
+            }
+          }
           environment {
             GOOGLE_SERVICES = credentials('google-services')
           }
           steps {
-            checkout scm
-            withDockerContainer(image: 'circleci/android:api-28-node', args: '-u root') {
-              sh """
-              apt update
-              apt install gradle
-              npm -g install cordova
-              cp ${GOOGLE_SERVICES} ./fixtures/google-services.json
-              ./scripts/build-testing-app.sh
-              """
-              stash includes: 'testing-app/bs-app-url.txt', name: 'android-testing-app'
-            }
+            sh """
+            cp ${GOOGLE_SERVICES} ./fixtures/google-services.json
+            ./scripts/build-testing-app.sh
+            """
+            stash includes: 'testing-app/bs-app-url.txt', name: 'android-testing-app'
+            stash includes: 'testing-app/package-lock.json', name: 'package-lock'
           }
         }
 
@@ -53,37 +50,38 @@ pipeline {
             MOBILE_PLATFORM = 'ios'
           }
           steps {
-            checkout scm
             sh """#!/usr/bin/env bash -l
             npm -g install cordova
             security unlock-keychain -p $KEYCHAIN_PASS && ./scripts/build-testing-app.sh
             """
-            stash includes: 'testing-app/bs-app-url.txt', name: 'ios-testing-app'        
+            stash includes: 'testing-app/bs-app-url.txt', name: 'ios-testing-app'
           }
         }
       }
     }
 
     stage('Testing') {
+      agent {
+        dockerfile {
+          dir 'containers/node/'
+          filename 'Dockerfile'
+          label 'psi_rhel8'
+          args '--volume /var/run/docker.sock:/var/run/docker.sock --network host'
+        }
+      }
       stages {
         stage('Start services') {
           steps {
-              sh """
-              docker network create aerogear || true
-              docker-compose up -d
-              # To remove ownership of root user from testing-app folder
-              sudo chown -R jenkins:jenkins .
-              """
+            sh 'sudo docker-compose up -d'
           }
         }
         stage('Install dependencies for tests') {
             steps {
-                withDockerContainer(image: 'circleci/node:dubnium-stretch', args: '-u root') {
-                  sh """
-                  npm install
-                  npm install mocha-jenkins-reporter
-                  """
-                }
+              sh """
+              npm install
+              npm install mocha-jenkins-reporter
+              """
+              unstash 'package-lock'
             }
         }
         stage('Test android') {
@@ -108,9 +106,8 @@ pipeline {
       post { 
         always {
           sh """
-          docker-compose logs --no-color > docker-compose.log
-          docker-compose down
-          docker network rm aerogear || true
+          sudo docker-compose logs --no-color > docker-compose.log
+          sudo docker-compose down
           """
           archiveArtifacts 'docker-compose.log'
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,8 @@ pipeline {
             ./scripts/build-testing-app.sh
             """
             stash includes: 'testing-app/bs-app-url.txt', name: 'android-testing-app'
+            // make the package-lock.json available for the testing
+            // because it is requested by the metrics test
             stash includes: 'testing-app/package-lock.json', name: 'package-lock'
           }
         }

--- a/containers/android/Dockerfile
+++ b/containers/android/Dockerfile
@@ -1,0 +1,13 @@
+FROM circleci/android:api-28-node
+
+USER root
+
+RUN apt update \
+    && apt install gradle
+
+RUN npm -g install cordova
+
+RUN useradd -m -u 1001 jenkins
+
+ENV HOME=/home/jenkins
+USER jenkins

--- a/containers/node/Dockerfile
+++ b/containers/node/Dockerfile
@@ -1,0 +1,8 @@
+FROM circleci/node:dubnium-stretch
+
+USER root
+
+RUN useradd -m -u 1001 jenkins \
+    && echo "jenkins ALL=NOPASSWD: ALL" > /etc/sudoers.d/60-jenkins
+
+USER jenkins

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,8 +46,3 @@ services:
       POSTGRES_DATABASE: ups
     depends_on:
       - upsdb
-
-networks:
-  default:
-    external:
-      name: aerogear


### PR DESCRIPTION
## Reason:

Containers running inside Jenkins pipelines share the workspace with the host machine (rhel), if we execute them as root they will create files owned by root which means that the jenkins user running on the host machine (rhel) will not be able to clean the workspace after or before the test execution. 

I founded this issue really annoying while testing the typescript branch.

Pipeline execution: https://mobile-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/blue/organizations/jenkins/test-aerogear-integration-tests/detail/improve-pipeline/31/pipeline
