### PR TITLE
Trigger the master nightly using declerative pipeline definition

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ def runIntegrationTests() {
 pipeline {
   agent none
   triggers {
-    cron('H H(0-2) * * *')
+    cron(env.BRANCH_NAME == 'master' ? 'H H(0-2) * * *' : '')
   }
   environment {
     BROWSERSTACK_USER = credentials('browserstack-user')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,9 @@ def runIntegrationTests() {
 
 pipeline {
   agent none
+  triggers {
+    cron('H H(0-2) * * *')
+  }
   environment {
     BROWSERSTACK_USER = credentials('browserstack-user')
     BROWSERSTACK_KEY = credentials('browserstack-key')


### PR DESCRIPTION
**Reason**:
The declarative pipeline will be our single source of truth, the next step will be substitute the integration-test job in the master with this one: https://mobile-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/aerogear-integration-tests/job/master/